### PR TITLE
bugfix to allow passing booleans to setPublicStatus

### DIFF
--- a/etherpad-lite-client.php
+++ b/etherpad-lite-client.php
@@ -267,6 +267,9 @@ class EtherpadLiteClient {
 
   // sets a boolean for the public status of a pad 
   public function setPublicStatus($padID, $publicStatus){
+    if (is_boolean($publicStatus)) {
+      $publlicStatus = $publicStatus ? "true" : "false";
+    }
     return $this->post("setPublicStatus", array(
       "padID"        => $padID,
       "publicStatus" => $publicStatus


### PR DESCRIPTION
/api/1/setPublicStatus?apikey=xxx&padID=yyy&publicStatus=zzz expects a String "true" or "false". This Patch ensures the correct usage of this API by EtherpadLiteClient
